### PR TITLE
Added a new command that expands tokens on a supplied item

### DIFF
--- a/Cognifide.PowerShell.csproj
+++ b/Cognifide.PowerShell.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Console\Services\RemoteScriptCall.ashx.cs">
       <DependentUpon>RemoteScriptCall.ashx</DependentUpon>
     </Compile>
+    <Compile Include="PowerShellIntegrations\Commandlets\Data\ExpandTokensCommand.cs" />
     <Compile Include="PowerShellIntegrations\Commandlets\ExecuteScriptCommand.cs" />
     <Compile Include="PowerShellIntegrations\Commandlets\GetSessionCommand.cs" />
     <Compile Include="PowerShellIntegrations\Commandlets\Interactive\CloseWindowCommand.cs" />

--- a/PowerShellIntegrations/Commandlets/Data/ExpandTokensCommand.cs
+++ b/PowerShellIntegrations/Commandlets/Data/ExpandTokensCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Management.Automation;
+
+using Sitecore.Configuration;
+
+using Sitecore.Data;
+using Sitecore.Data.Items;
+
+namespace Cognifide.PowerShell.PowerShellIntegrations.Commandlets.Data
+{
+    [Cmdlet("Expand", "Tokens", DefaultParameterSetName = "Item")]
+    [OutputType(new[] { typeof(Item) })]
+    public class ExpandTokensCommand : BaseCommand
+    {
+        private static readonly MasterVariablesReplacer TokenReplacer = Factory.GetMasterVariablesReplacer();
+
+        [Parameter(Position = 0, Mandatory = true)]
+        public Item Item { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            Item.Editing.BeginEdit();
+            try
+            {
+                TokenReplacer.ReplaceItem(Item);
+                Item.Editing.EndEdit();
+            }
+            catch (Exception ex)
+            {
+                Item.Editing.CancelEdit();
+                throw ex;
+            }
+
+            PSObject psobj = ItemShellExtensions.GetPsObject(SessionState, Item);
+            WriteObject(psobj, false);
+        }
+    }
+}


### PR DESCRIPTION
This command uses an instance of the MasterVariablesReplacer for the
given Sitecore solution as defined in the instance's Web.config to
replace tokens on a supplied item.
