### PR TITLE
Fixing NuGet ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ publish/
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+#/packages/
 
 # Windows Azure Build Output
 csx


### PR DESCRIPTION
Updated 'packages/' to '/packages/' otherwise the ignore also ignores existing folders in the solution which are also named packages.