### PR TITLE
#935: Correctly handle -Recurse switch on Add-ItemVersion

### DIFF
--- a/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
@@ -89,14 +89,15 @@ namespace Cognifide.PowerShell.Commandlets.Data
                     {
                         WriteItem(latestVersion);
                     }
-                    if (Recurse)
-                    {
-                        foreach (Item childItem in item.Children)
-                        {
-                            childItem.Versions.GetLatestVersion(item.Language);
-                            ProcessItem(childItem);
-                        }
-                    }
+                }
+            }
+
+            if (Recurse)
+            {
+                foreach (Item childItem in item.Children)
+                {
+                    childItem.Versions.GetLatestVersion(item.Language);
+                    ProcessItem(childItem);
                 }
             }
         }


### PR DESCRIPTION
All children were being processed for each target language instead of just once per item.

Fixes #935 