### PR TITLE
#940 | Add-ItemVersion incorrectly copies empty fields like "__Final Renderings"

### DIFF
--- a/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
@@ -125,7 +125,6 @@ namespace Cognifide.PowerShell.Commandlets.Data
                             }
                         }
                         targetItem.Editing.EndEdit();
-                        targetItem.Editing.AcceptChanges();
                     }
                     WriteItem(targetItem);
                 }

--- a/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Data/AddItemVersionCommand.cs
@@ -121,7 +121,7 @@ namespace Cognifide.PowerShell.Commandlets.Data
                         {
                             if (ShouldProcessField(field, itemWasCreated))
                             {
-                                targetItem.Fields[field.Name].SetValue(field.Value, true);
+                                targetItem.Fields[field.Name].Value = field.GetValue(true, true);
                             }
                         }
                         targetItem.Editing.EndEdit();


### PR DESCRIPTION
The getter of `field.Value` returns an empty string instead of `null` so I've changed it to use `field.GetValue(true, true)` as the `field.Value` property is doing underneath.

The setter of `field.Value` will also correctly reset the field if set to `null`.

`AcceptChanges()` is unnecessary as it is already being called by `EndEdit()`.