### PR TITLE
Get-Jobs

### DIFF
--- a/Cognifide.PowerShell/Cognifide.PowerShell.csproj
+++ b/Cognifide.PowerShell/Cognifide.PowerShell.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Commandlets\Interactive\Messages\InvokeJavaScriptMessage.cs" />
     <Compile Include="Commandlets\Interactive\InvokeJavaScriptCommand.cs" />
     <Compile Include="Commandlets\Interactive\Messages\ShowSuspendDialogMessage.cs" />
+    <Compile Include="Commandlets\Jobs\GetJobsCommand.cs" />
     <Compile Include="Commandlets\Packages\GetPackageItemCommand.cs" />
     <Compile Include="Commandlets\Presentation\MergeLayoutCommand.cs" />
     <Compile Include="Commandlets\Security\Accounts\BaseSecurityCommand.cs" />

--- a/Cognifide.PowerShell/Commandlets/Jobs/GetJobsCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Jobs/GetJobsCommand.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Web;
+
+namespace Cognifide.PowerShell.Commandlets.Jobs
+{
+    [Cmdlet(VerbsCommon.Get, "Jobs")]
+    [OutputType(typeof (Sitecore.Jobs.Job))]
+    public class GetJobsCommand : BaseCommand
+    {
+        protected override void ProcessRecord()
+        {
+            var jobs = Sitecore.Jobs.JobManager.GetJobs();
+            foreach (var job in jobs)
+            {
+                WriteObject(job);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I was used to use the TaskManager for Sitecore package to visualize the publishing/indexing tasks status. But I really like your powershell module so I have added a Get-Jobs command. It work great and I will also do a pull request of the "book" for the new documentation page. 

The only missing thing to really have a task manager could be the possibility to refresh the list view every x seconds. I have try it with the Update-ListView command every X seconds but it looks that this catch the focus. This mean that the rest of the api become unclickable.

I hope that you will accept this pull request.

Regards,

Benjamin Vangansewinkel
