### PR TITLE
#1047 | Powershell Toolbox - entries order

### DIFF
--- a/Cognifide.PowerShell/Client/Commands/MenuItems/ScriptLibraryMenuItem.cs
+++ b/Cognifide.PowerShell/Client/Commands/MenuItems/ScriptLibraryMenuItem.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Cognifide.PowerShell.Client.Controls;
 using Cognifide.PowerShell.Core.Extensions;
 using Cognifide.PowerShell.Core.Modules;
 using Cognifide.PowerShell.Core.Settings;
@@ -113,11 +112,17 @@ namespace Cognifide.PowerShell.Client.Commands.MenuItems
 
         protected virtual void SortMenuItems(List<Control> menuItems)
         {
+            string GetRawSortOrderValue(MenuItem menuItem)
+            {
+                var rawSortOrder = menuItem.Attributes[FieldIDs.Sortorder.ToString()];
+                return String.IsNullOrWhiteSpace(rawSortOrder) ? "0" : rawSortOrder;
+            }
+
             int GetSortOrder(MenuItem x, MenuItem y)
             {
-                var rawSortOrderX = x.Attributes[FieldIDs.Sortorder.ToString()];
-                var rawSortOrderY = y.Attributes[FieldIDs.Sortorder.ToString()];
-                if (string.IsNullOrEmpty(rawSortOrderX) || string.IsNullOrEmpty(rawSortOrderY) || rawSortOrderX.Is(rawSortOrderY))
+                var rawSortOrderX = GetRawSortOrderValue(x);
+                var rawSortOrderY = GetRawSortOrderValue(y);
+                if (rawSortOrderX.Is(rawSortOrderY))
                 {
                     return string.Compare(x.Header, y.Header, StringComparison.OrdinalIgnoreCase);
                 }


### PR DESCRIPTION
I found the problem for a case when there is no sort order (empty) or there is empty value and `0`

**Before**
```
B2 [5]
B1 [4]
A2 [200]
null []
BA3 [4]
C [6]
D [-20]
A1 [100]
```

**After**
```
D [-20]
B1 [4]
BA3 [4]
B2 [5]
C [6]
A1 [100]
A2 [200]
null []
```


**Expected**
 
```
D [-20]
null []
B1 [4]
BA3 [4]
B2 [5]
C [6]
A1 [100]
A2 [200]
```