### PR TITLE
Adding Cmdlets for editing RenderingDefinition Parameters

### DIFF
--- a/Cognifide.PowerShell/Cognifide.PowerShell.csproj
+++ b/Cognifide.PowerShell/Cognifide.PowerShell.csproj
@@ -125,6 +125,7 @@
     </Reference>
     <Reference Include="Sitecore.Mvc, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sitecore.Mvc.NoReferences.8.2.170728\lib\NET452\Sitecore.Mvc.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Sitecore.Update, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sitecore.Update.NoReferences.8.2.170728\lib\NET452\Sitecore.Update.dll</HintPath>
@@ -195,7 +196,11 @@
     <Compile Include="Commandlets\Interactive\Messages\ShowSuspendDialogMessage.cs" />
     <Compile Include="Commandlets\Jobs\GetSitecoreJobCommand.cs" />
     <Compile Include="Commandlets\Packages\GetPackageItemCommand.cs" />
+    <Compile Include="Commandlets\Presentation\BaseRenderingParametersCommand.cs" />
+    <Compile Include="Commandlets\Presentation\RemoveRenderingParametersCommand.cs" />
+    <Compile Include="Commandlets\Presentation\GetRenderingParametersCommand.cs" />
     <Compile Include="Commandlets\Presentation\MergeLayoutCommand.cs" />
+    <Compile Include="Commandlets\Presentation\SetRenderingParametersCommand.cs" />
     <Compile Include="Commandlets\Security\Accounts\BaseSecurityCommand.cs" />
     <Compile Include="Core\Extensions\CustomFieldAccessor.cs" />
     <Compile Include="Core\Extensions\ExpressionExtensions.cs" />

--- a/Cognifide.PowerShell/Commandlets/Presentation/BaseRenderingParametersCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Presentation/BaseRenderingParametersCommand.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Specialized;
+using Cognifide.PowerShell.Commandlets.Interactive;
+using Sitecore.Diagnostics;
+using Sitecore.Layouts;
+using Sitecore.Text;
+using Sitecore.Web;
+
+namespace Cognifide.PowerShell.Commandlets.Presentation
+{
+    public class BaseRenderingParametersCommand : BaseShellCommand
+    {
+        protected NameValueCollection GetParameters(RenderingDefinition renderingDefinition)
+        {
+            return WebUtil.ParseUrlParameters(renderingDefinition.Parameters ?? string.Empty);
+        }
+    }
+}

--- a/Cognifide.PowerShell/Commandlets/Presentation/GetRenderingParametersCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Presentation/GetRenderingParametersCommand.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Linq;
+using System.Management.Automation;
+using Sitecore.Layouts;
+
+namespace Cognifide.PowerShell.Commandlets.Presentation
+{
+    [Cmdlet(VerbsCommon.Get, "RenderingParameters")]
+    [OutputType(typeof(Hashtable))]
+    public class GetRenderingParametersCommand : BaseRenderingParametersCommand
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public RenderingDefinition Rendering { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var parameters = GetParameters(Rendering);
+            WriteObject(new Hashtable(parameters.AllKeys.ToDictionary(k => k, k => parameters[k])));
+        }
+    }
+}

--- a/Cognifide.PowerShell/Commandlets/Presentation/RemoveRenderingParametersCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Presentation/RemoveRenderingParametersCommand.cs
@@ -1,0 +1,31 @@
+﻿using System.Management.Automation;
+using Cognifide.PowerShell.Commandlets.Interactive;
+using Sitecore.Layouts;
+using Sitecore.Text;
+
+namespace Cognifide.PowerShell.Commandlets.Presentation
+{
+    [Cmdlet(VerbsCommon.Remove, "RenderingParameters")]
+    [OutputType(typeof(RenderingDefinition))]
+    public class RemoveRenderingParametersCommand : BaseRenderingParametersCommand
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public RenderingDefinition Rendering { get; set; }
+
+        [Parameter(Mandatory = true, Position = 1)]
+        public string[] Parameter { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var parameters = this.GetParameters(Rendering);
+
+            foreach (var name in Parameter)
+            {
+                parameters.Remove(name);
+            }
+
+            Rendering.Parameters = new UrlString(parameters).ToString();
+            WriteObject(Rendering);
+        }
+    }
+}

--- a/Cognifide.PowerShell/Commandlets/Presentation/SetRenderingParametersCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Presentation/SetRenderingParametersCommand.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Specialized;
+using System.Management.Automation;
+using Sitecore.Layouts;
+using Sitecore.Text;
+
+namespace Cognifide.PowerShell.Commandlets.Presentation
+{
+    [Cmdlet(VerbsCommon.Set, "RenderingParameters")]
+    [OutputType(typeof(RenderingDefinition))]
+    public class SetRenderingParametersCommand : BaseRenderingParametersCommand
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public RenderingDefinition Rendering { get; set; }
+
+        [Parameter(Mandatory = true, Position = 1)]
+        public Hashtable Parameter { get; set; }
+
+        [Parameter]
+        public SwitchParameter Overwrite { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var parameters = Overwrite.IsPresent ? new NameValueCollection() : GetParameters(Rendering);
+
+            foreach (string key in Parameter.Keys)
+            {
+                parameters.Add(key, System.Convert.ToString(Parameter[key]));
+            }
+
+            Rendering.Parameters = new UrlString(parameters).ToString();
+            WriteObject(Rendering);
+        }
+    }
+}


### PR DESCRIPTION
Examples
```powershell
#remove obslete rendering parameter
gi /sitecore/content/ZTenant/YSite/Home  | % {
    $item = $_
    get-rendering -item $item -parameter @{ "obsleteParameter"="*" } `
        | % { remove-renderingparameters  $_ -parameter "obsleteParameter" } `
        | % { set-rendering -item $item -instance $_ }
}

# check how rendering variants are used
gi /sitecore/content/ZTenant/YSite/Home  | % {
    $item = $_
    get-rendering -item $item -final | %{ (get-renderingparameters $_)["FieldNames"] } | group
}
```

Those two seem to bring something new. set-renderingparameter is another story. Is is not needed as setting a parameter can be done with set-rendering. On the other hand I expect this cmdlet to be there because `get` is there, so should be `set`. Also there is this thing if you want to change RenderingDefinition Parameter and pass it somewhere you will need to pass both values until `set-rendering` is used to 'seal the deal'.

```powershell
# setting parameter value
gi /sitecore/content/ZTenant/YSite/Home  | % {
    $item = $_
    get-rendering -item $item  `
        | % { set-renderingparameters  $_ -parameter @{ "obsleteParameter"="cssClass" } } `
        | % { set-rendering -item $item -instance $_ }
}
```