### PR TITLE
Fixed Date Range Search issue

### DIFF
--- a/Cognifide.PowerShell/Commandlets/Data/Search/BaseSearchCommand.cs
+++ b/Cognifide.PowerShell/Commandlets/Data/Search/BaseSearchCommand.cs
@@ -177,11 +177,11 @@ namespace Cognifide.PowerShell.Commandlets.Data.Search
                     break;
                 case DateTime[] _:
                     var pairDateTime = (DateTime[])value;
-                    var leftDateTime = pairDateTime[0].ToString("yyyyMMdd");
-                    var rightDateTime = pairDateTime[1].ToString("yyyyMMdd");
+                    var leftDateTime = pairDateTime[0];
+                    var rightDateTime = pairDateTime[1];
                     predicate = criteria.Invert
-                        ? predicate.AddPredicate(i => !i[criteria.Field].Between(leftDateTime, rightDateTime, inclusion).Boost(boost), operation)
-                        : predicate.AddPredicate(i => i[criteria.Field].Between(leftDateTime, rightDateTime, inclusion).Boost(boost), operation);
+                        ? predicate.AddPredicate(i => !((DateTime)i[(ObjectIndexerKey)criteria.Field]).Between(leftDateTime, rightDateTime, inclusion).Boost(boost), operation)
+                        : predicate.AddPredicate(i => ((DateTime)i[(ObjectIndexerKey)criteria.Field]).Between(leftDateTime, rightDateTime, inclusion).Boost(boost), operation);
                     break;
                 case double[] _:
                     var pairDouble = (double[])value;


### PR DESCRIPTION
Updated Date Range Search to cast to DateTime to fix date queries with both Coveo/Solr

Sample Test Query

$criteria = @(
 @{
    Field = "__smallcreateddate"
    Filter = "InclusiveRange"
    Value = [datetime[]]@([datetime]"05/05/2019", [datetime]::Today)
  }
)

$props = @{
  Index = "Coveo_web_index "
  Criteria = $criteria
  First = 15
}

Find-Item @props