### PR TITLE
Integration with EE doesn't work in Sitecore 9.0.1

### DIFF
--- a/Spe/App_Config/Include/Spe/Spe.config
+++ b/Spe/App_Config/Include/Spe/Spe.config
@@ -232,13 +232,18 @@
         <processor patch:before="processor[@type='Sitecore.Pipelines.GetContentEditorWarnings.RunRules, Sitecore.Kernel']"
            type="Spe.Core.Settings.Authorization.ContentEditorSecurityWarning, Spe" />
       </getContentEditorWarnings>
-      <group groupName="ExperienceEditor" name="ExperienceEdiitor">
+      <!-- for Sitecore 9 -->
+      <group groupName="ExperienceEditor" name="ExperienceEditor">
        <pipelines>
         <getPageEditorNotifications>
           <processor type="Spe.Integrations.Pipelines.PageEditorNotificationScript, Spe"/>
         </getPageEditorNotifications>
        </pipelines>
       <group>
+      <!-- for Sitecore 8.2 -->
+      <getPageEditorNotifications>
+         <processor type="Spe.Integrations.Pipelines.PageEditorNotificationScript, Spe"/>
+      </getPageEditorNotifications>
       <getLookupSourceItems>
         <processor
           patch:before="*[@type='Sitecore.Pipelines.GetLookupSourceItems.ProcessQuerySource, Sitecore.Kernel']"


### PR DESCRIPTION
PageEditorNotificationScript is patched in the wrong place. In Sitecore 9 <getPageEditorNotifications> is inside a group.