### PR TITLE
Add option - leave package on the server

### DIFF
--- a/unicorn/SPE/Scripts/SPE/SPE/Tools/Package Generator/Content Editor/Context Menu/Packaging/Quick Download Tree as Package.yml
+++ b/unicorn/SPE/Scripts/SPE/SPE/Tools/Package Generator/Content Editor/Context Menu/Packaging/Quick Download Tree as Package.yml
@@ -28,8 +28,9 @@ SharedFields:
         @{ Name = "Author"; Value = [Sitecore.Context]::User.Profile.FullName; Tab="Package Metadata"},
         @{ Name = "Publisher"; Value = [Sitecore.SecurityModel.License.License]::Licensee; Tab="Package Metadata"},
         @{ Name = "Version"; Value = $selectedItem.Version; Tab="Package Metadata"},
-        @{ Name = "Readme"; Title="Readme"; Lines=10; Tab="Package Metadata"},
+        @{ Name = "Readme"; Title="Readme"; Lines=8; Tab="Package Metadata"},
         @{ Name = "AsXml"; Title="Download Package as XML"; Value=[bool]$False; Editor="bool"; Tab="Package Metadata" },
+        @{ Name = "LeavePackage"; Title="Leave the package on the server"; Value=[bool]$False; Editor="bool"; Tab="Package Metadata" },
         @{ Name = "IncludeItems"; Title="Items to include in package"; Value="RootAndDescendants"; Options=$rootOptions; OptionTooltips = $rootOptionTooltips; Tooltip = "Hover over each option to view a short description."; Hint = "The package will dynamically include the items based on your selection below. <br /><br />Root : '$($selectedItem.ProviderPath)'"; Editor="combo"; Tab="Installation Options" },
         @{ Name = "Mode"; Title="Installation Options"; Value = "Merge-Merge"; Options = $installOptions; OptionTooltips = $installOptionsTooltips; Tooltip = "Hover over each option to view a short description."; Hint = "How should the installer behave if the package contains items that already exist?"; Editor="combo"; Tab="Installation Options"}
     )
@@ -125,7 +126,10 @@ SharedFields:
     
     Export-Package -Project $package -Path $packageFileName -Zip:$(!$AsXml)
     Download-File "$($SitecorePackageFolder)\$($packageFileName)"
-    Remove-Item "$($SitecorePackageFolder)\$($packageFileName)"
+    if( -not $LeavePackage )
+    {
+        Remove-Item "$($SitecorePackageFolder)\$($packageFileName)"
+    }
     Close-Window
 - ID: "ba3f86a2-4a1c-4d78-b63d-91c2779c1b5e"
   Hint: __Sortorder


### PR DESCRIPTION
I use this option often to backup Sitecore items. In this case is good to leave package on the server, to easy restore package.
Readme field size was changed, otherwise we have to scroll down to see new option.
![2020-03-04_22-18-41](https://user-images.githubusercontent.com/36140686/75924700-b2a4ab00-5e67-11ea-8717-098f3631a236.png)