### PR TITLE
Add more options to control item name and display name

### DIFF
--- a/unicorn/SPE/Scripts/SPE/SPE/Core/Platform/Toolbox/Re-create site from sitemap.yml
+++ b/unicorn/SPE/Scripts/SPE/SPE/Core/Platform/Toolbox/Re-create site from sitemap.yml
@@ -23,7 +23,9 @@ SharedFields:
         @{ Name = "createAt"; Title="Item to create the site under"; Root="/sitecore/content/"},
         @{ Name = "itemTemplate"; Title="Template to use for pages"; Root="/sitecore/templates/"},
         @{ Name = "prefix"; Value=""; Placeholder = "https://www.sitecore.net/"; Title="Prefix to chop off URLs"; },
-        @{ Name = "postfix"; Value=".aspx$"; Title="Postfix regex to chop off URLs";} `
+        @{ Name = "postfix"; Value=".aspx$"; Title="Postfix regex to chop off URLs";},
+        @{ Name = "charsToRemove"; Value=""; Title="Characters to remove from Item Name separated by a comma";},
+        @{ Name = "titleCase"; Value=$false; Title="Converts the item name and display name to title case (item name = Item Name)";} `
         -Description "Create pages using the sitemap of an existing site." `
         -Title "Create Site From Sitemap" -Width 600 -Height 400 `
         -OkButtonName "Proceed" -CancelButtonName "Abort" -Icon ([regex]::Replace($PSScript.Appearance.Icon, "Office", "OfficeWhite", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase))
@@ -61,7 +63,21 @@ SharedFields:
       $parentPath = Split-Path $itemName -parent
       $itemName = Split-Path $itemName -leaf
       
+      if( $titleCase -eq $true )
+      {
+        $itemName = (Get-Culture).TextInfo.ToTitleCase($itemName)    
+      }
+      
       $itemValidName = CreateValidItemName($itemName)
+      
+      if( -not [String]::IsNullOrEmpty($charsToRemove) )
+      {
+          $charsToRemove = $charsToRemove -split ','
+  
+          $charsToRemove | ForEach-Object {
+            $itemValidName = $itemValidName -replace $_,""
+        }
+      }
       
       if(-not (Test-Path "$createAt\$parentPath")){
         if($parentPath.Length -gt 2){


### PR DESCRIPTION
By default, this script does not apply any changes to the default behavior except to add two options:

- Characters to remove from Item Name separated by a comma
- Converts the item name and display name to title case

If the page name in sitemap.xml is contact-us
By default:
itemName = contact-us and displayName=contact us
![image](https://user-images.githubusercontent.com/831971/98544059-b5c42680-2293-11eb-9fbd-9024403fc468.png)

With new options:
itemName=ContactUs and dispayName=Concact Us
![image](https://user-images.githubusercontent.com/831971/98544098-c379ac00-2293-11eb-8c6d-a4ff8711f3fe.png)
