### PR TITLE
Update items related to launchpad icons

### DIFF
--- a/unicorn/SPE/UI/Launchpad ISE/PowerShell ISE.yml
+++ b/unicorn/SPE/UI/Launchpad ISE/PowerShell ISE.yml
@@ -13,7 +13,7 @@ SharedFields:
   Value: 300
 - ID: "d25b56d4-23b6-4462-be25-b6a6d7f38e13"
   Hint: Icon
-  Value: powershell/32x32/ise8.png
+  Value: LaunchPadIcons/32x32/PowerShell ISE.png
 - ID: "dec8d2d5-e3cf-48b6-a653-8e69e2716641"
   Hint: __Security
   Value: |

--- a/unicorn/SPE/UI/Launchpad Reports/PowerShell Reports.yml
+++ b/unicorn/SPE/UI/Launchpad Reports/PowerShell Reports.yml
@@ -13,7 +13,7 @@ SharedFields:
   Value: 400
 - ID: "d25b56d4-23b6-4462-be25-b6a6d7f38e13"
   Hint: Icon
-  Value: Office/32x32/chart_donut.png
+  Value: LaunchPadIcons/32x32/PowerShell Reports.png
 - ID: "dec8d2d5-e3cf-48b6-a653-8e69e2716641"
   Hint: __Security
   Value: |


### PR DESCRIPTION
In the scope of LaunchPad redesign work the icons of all apps were changed. In this PR I have updated the definition of the icons to align them with the new LaunchPad design. Please, link my PR with [this issue](https://github.com/SitecorePowerShell/Console/issues/1219).

**Note:** All icons are located at _Sitecore.Themes_ repository.