### PR TITLE
Update Wait-RemoteSitecoreJob.ps1

### DIFF
--- a/Modules/SPE/Wait-RemoteSitecoreJob.ps1
+++ b/Modules/SPE/Wait-RemoteSitecoreJob.ps1
@@ -88,7 +88,6 @@
                     Write-Verbose "Finished polling job $($id)."
                 } else {
                     Write-Verbose "Polling job $($response.Name). Status : $($response.Status)."
-                    Start-Sleep -Seconds $Delay
                 }
         }
         if ($keepRunning -ne $Ids.Count) # Only sleep if we're not 'done' waiting for jobs

--- a/Modules/SPE/Wait-RemoteSitecoreJob.ps1
+++ b/Modules/SPE/Wait-RemoteSitecoreJob.ps1
@@ -45,7 +45,7 @@
         [pscustomobject]$Session,
 
         [ValidateNotNull()]
-        [string]$Id,
+        [string[]]$Ids,
 
         [int]$Delay = 1
     )
@@ -77,16 +77,22 @@
         }
     }
 
-    $keepRunning = $true
-    while($keepRunning) {
-        $response = Invoke-RemoteScript -Session $session -ScriptBlock $doneScript
-        if($response -and $response.IsDone) {
-            $keepRunning = $false
-            Write-Verbose "Polling job $($response.Name). Status : $($response.Status)."
-            Write-Verbose "Finished polling job $($id)."
-            Invoke-RemoteScript -Session $session -ScriptBlock $finishScript
-        } else {
-            Write-Verbose "Polling job $($response.Name). Status : $($response.Status)."
+    $keepRunning = 0
+    while($keepRunning -ne $Ids.Count) {
+        foreach ($id in $Ids)
+        {
+                $response = Invoke-RemoteScript -Session $session -ScriptBlock $doneScript
+                if($response -and $response.IsDone) {
+                    $keepRunning++
+                    Write-Verbose "Polling job $($response.Name). Status : $($response.Status)."
+                    Write-Verbose "Finished polling job $($id)."
+                } else {
+                    Write-Verbose "Polling job $($response.Name). Status : $($response.Status)."
+                    Start-Sleep -Seconds $Delay
+                }
+        }
+        if ($keepRunning -ne $Ids.Count) # Only sleep if we're not 'done' waiting for jobs
+        {
             Start-Sleep -Seconds $Delay
         }
     }


### PR DESCRIPTION
This PR is to fix two issues with Wait-RemoteSitecoreJob.ps1

1) As mentioned in https://github.com/SitecorePowerShell/Console/issues/1266#issue-1248688022 Wait-RemoteSitecoreJob 'fails' when the job finishes, this PR removes the "$finishscript" call that is not needed.

2) The Wait-RemoteSitecoreJob  did not support multiple JobId's being passed. Updated to support the passing of a String Arraylist of job Id's (one or many), the foreach loop then returns the status of each job with a 'sleep' time between each.
The 'while' loop then exits when one or many jobs have returned 'done'.