### PR TITLE
Implement OAuth bearer token support and improve AccessToken handling

### DIFF
--- a/Modules/SPE/Invoke-RemoteScript.ps1
+++ b/Modules/SPE/Invoke-RemoteScript.ps1
@@ -193,9 +193,9 @@ function Invoke-RemoteScript {
     	.LINK
     	    Stop-ScriptSession
 
-        .PARAMETER AccessToken
-            Specifies an external OAuth bearer token to use for authentication.
-            When provided, this value is sent as the Authorization: Bearer header.
+    .PARAMETER AccessToken
+        Specifies an external OAuth bearer token to use for authentication.
+        When provided, this value is sent as the Authorization: Bearer header.
     #>
    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName="InProcess")]
     param(

--- a/Modules/SPE/Invoke-RemoteScript.ps1
+++ b/Modules/SPE/Invoke-RemoteScript.ps1
@@ -192,6 +192,10 @@ function Invoke-RemoteScript {
 
     	.LINK
     	    Stop-ScriptSession
+
+        .PARAMETER AccessToken
+            Specifies an external OAuth bearer token to use for authentication.
+            When provided, this value is sent as the Authorization: Bearer header.
     #>
    [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName="InProcess")]
     param(
@@ -219,6 +223,10 @@ function Invoke-RemoteScript {
 
         [Parameter(ParameterSetName='Uri')]
         [string]$SharedSecret,
+
+        [Parameter(ParameterSetName='Uri')]
+        [Parameter(ParameterSetName='Session')]
+        [string]$AccessToken,
 
         [Parameter(ParameterSetName='Uri')]
         [System.Management.Automation.PSCredential]
@@ -298,6 +306,9 @@ function Invoke-RemoteScript {
             $Username = $Session.Username
             $Password = $Session.Password
             $SharedSecret = $Session.SharedSecret
+            if([string]::IsNullOrEmpty($AccessToken)) {
+                $AccessToken = $Session.AccessToken
+            }
             $SessionId = $Session.SessionId
             $Credential = $Session.Credential
             $UseDefaultCredentials = $Session.UseDefaultCredentials
@@ -324,7 +335,9 @@ function Invoke-RemoteScript {
             $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
             $client = New-Object -TypeName System.Net.Http.Httpclient $handler
 
-            if(![string]::IsNullOrEmpty($SharedSecret)) {
+            if(![string]::IsNullOrEmpty($AccessToken)) {
+                $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $AccessToken)
+            } elseif(![string]::IsNullOrEmpty($SharedSecret)) {
                 $token = New-Jwt -Algorithm 'HS256' -Issuer 'SPE Remoting' -Audience ($uri.GetLeftPart([System.UriPartial]::Authority)) -Name $Username -SecretKey $SharedSecret -ValidforSeconds 30
                 $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $token)
             } else {
@@ -422,6 +435,9 @@ function Invoke-RemoteScriptAsync {
         [hashtable]$Arguments,
 
         [Parameter()]
+        [string]$AccessToken,
+
+        [Parameter()]
         [switch]$Raw
     )
 
@@ -477,6 +493,9 @@ function Invoke-RemoteScriptAsync {
     $newScriptBlock = $scriptBlock.ToString()
     $Username = $Session.Username
     $Password = $Session.Password
+    if([string]::IsNullOrEmpty($AccessToken)) {
+        $AccessToken = $Session.AccessToken
+    }
     $SessionId = $Session.SessionId
     $Credential = $Session.Credential
     $UseDefaultCredentials = $Session.UseDefaultCredentials
@@ -489,8 +508,12 @@ function Invoke-RemoteScriptAsync {
     $handler = New-Object System.Net.Http.HttpClientHandler
     $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
     $client = New-Object -TypeName System.Net.Http.Httpclient $handler
-    $authBytes = [System.Text.Encoding]::GetEncoding("iso-8859-1").GetBytes("$($Username):$($Password)")
-    $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Basic", [System.Convert]::ToBase64String($authBytes))
+    if(![string]::IsNullOrEmpty($AccessToken)) {
+        $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $AccessToken)
+    } else {
+        $authBytes = [System.Text.Encoding]::GetEncoding("iso-8859-1").GetBytes("$($Username):$($Password)")
+        $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Basic", [System.Convert]::ToBase64String($authBytes))
+    }
        
     if ($Credential) {
         $handler.Credentials = $Credential

--- a/Modules/SPE/New-ScriptSession.ps1
+++ b/Modules/SPE/New-ScriptSession.ps1
@@ -23,6 +23,10 @@ function New-ScriptSession {
         .PARAMETER SharedSecret
             Specifies the SharedSecret used to authenticate the identity. 
         
+        .PARAMETER AccessToken
+            Specifies an external OAuth bearer token (e.g. an XM Cloud access token) used for
+            authentication.  When provided, Username/Password and SharedSecret are not required.
+        
         .PARAMETER Timeout
             Specifies the duration of the wait, in seconds.
 
@@ -47,7 +51,8 @@ function New-ScriptSession {
     #>
     [CmdletBinding(DefaultParameterSetName="All")]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = "Password")]
+        [Parameter(Mandatory = $true, ParameterSetName = "SharedSecret")]
         [ValidateNotNullOrEmpty()]
         [string]$Username = $null,
 
@@ -58,6 +63,10 @@ function New-ScriptSession {
         [Parameter(Mandatory = $true, ParameterSetName = "SharedSecret")]
         [ValidateNotNullOrEmpty()]
         [string]$SharedSecret = $null,
+
+        [Parameter(Mandatory = $true, ParameterSetName = "AccessToken")]
+        [ValidateNotNullOrEmpty()]
+        [string]$AccessToken = $null,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -84,6 +93,7 @@ function New-ScriptSession {
             "Username" = [string]$Username
             "Password" = [string]$Password
             "SharedSecret" = [string]$SharedSecret
+            "AccessToken" = [string]$AccessToken
             "SessionId" = [string]$sessionId
             "Credential" = [System.Management.Automation.PSCredential]$Credential
             "UseDefaultCredentials" = [bool]$UseDefaultCredentials

--- a/Modules/SPE/Receive-RemoteItem.ps1
+++ b/Modules/SPE/Receive-RemoteItem.ps1
@@ -87,6 +87,12 @@ function Receive-RemoteItem {
 
         [Parameter(ParameterSetName='Uri and File')]
         [Parameter(ParameterSetName='Uri and Database')]
+        [Parameter(ParameterSetName='Session and File')]
+        [Parameter(ParameterSetName='Session and Database')]
+        [string]$AccessToken,
+
+        [Parameter(ParameterSetName='Uri and File')]
+        [Parameter(ParameterSetName='Uri and Database')]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -137,6 +143,9 @@ function Receive-RemoteItem {
             $Username = $Session.Username
             $Password = $Session.Password
             $SharedSecret = $Session.SharedSecret
+            if([string]::IsNullOrEmpty($AccessToken)) {
+                $AccessToken = $Session.AccessToken
+            }
             $Credential = $Session.Credential
             $UseDefaultCredentials = $Session.UseDefaultCredentials
             $ConnectionUri = $Session | ForEach-Object { $_.Connection.BaseUri }
@@ -166,7 +175,9 @@ function Receive-RemoteItem {
             $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
             $client = New-Object -TypeName System.Net.Http.Httpclient $handler
 
-            if(![string]::IsNullOrEmpty($SharedSecret)) {
+            if(![string]::IsNullOrEmpty($AccessToken)) {
+                $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $AccessToken)
+            } elseif(![string]::IsNullOrEmpty($SharedSecret)) {
                 $token = New-Jwt -Algorithm 'HS256' -Issuer 'SPE Remoting' -Audience ($uri.GetLeftPart([System.UriPartial]::Authority)) -Name $Username -SecretKey $SharedSecret -ValidforSeconds 30
                 $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $token)
             } else {

--- a/Modules/SPE/Send-RemoteItem.ps1
+++ b/Modules/SPE/Send-RemoteItem.ps1
@@ -79,6 +79,10 @@ function Send-RemoteItem {
         [string]$Password,
 
         [Parameter(ParameterSetName='Uri')]
+        [Parameter(ParameterSetName='Session')]
+        [string]$AccessToken,
+
+        [Parameter(ParameterSetName='Uri')]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -143,6 +147,9 @@ function Send-RemoteItem {
             $Username = $Session.Username
             $Password = $Session.Password
             $SharedSecret = $Session.SharedSecret
+            if([string]::IsNullOrEmpty($AccessToken)) {
+                $AccessToken = $Session.AccessToken
+            }
             $Credential = $Session.Credential
             $UseDefaultCredentials = $Session.UseDefaultCredentials
             $ConnectionUri = $Session | ForEach-Object { $_.Connection.BaseUri }
@@ -174,7 +181,9 @@ function Send-RemoteItem {
             $handler.AutomaticDecompression = [System.Net.DecompressionMethods]::GZip -bor [System.Net.DecompressionMethods]::Deflate
             $client = New-Object -TypeName System.Net.Http.Httpclient $handler
             
-            if(![string]::IsNullOrEmpty($SharedSecret)) {
+            if(![string]::IsNullOrEmpty($AccessToken)) {
+                $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $AccessToken)
+            } elseif(![string]::IsNullOrEmpty($SharedSecret)) {
                 $token = New-Jwt -Algorithm 'HS256' -Issuer 'SPE Remoting' -Audience ($uri.GetLeftPart([System.UriPartial]::Authority)) -Name $Username -SecretKey $SharedSecret -ValidforSeconds 30
                 $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", $token)
             } else {

--- a/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
+++ b/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
@@ -4,17 +4,26 @@
 
   PURPOSE
   =======
-  This file replaces the default SharedSecretAuthenticationProvider with
-  OAuthBearerTokenAuthenticationProvider, enabling SPE remoting to accept
-  external OAuth / OIDC bearer tokens (e.g. an XM Cloud access token with
-  scope "xmcloud.cm:admin") instead of requiring a Username/Password or a
+  This file is always deployed alongside the SPE assemblies.  It registers
+  OAuthBearerTokenAuthenticationProvider as the active authentication provider,
+  replacing the default SharedSecretAuthenticationProvider, so that SPE remoting
+  can accept external OAuth / OIDC bearer tokens (e.g. an XM Cloud access token
+  with scope "xmcloud.cm:admin") instead of requiring a Username/Password or a
   SharedSecret.
 
-  WHEN TO ENABLE
-  ==============
-  Enable this file (rename to Spe.OAuthBearer.config) on XM Cloud CM instances
-  or any Sitecore Cloud topology where callers already hold a valid OAuth access
-  token issued by the platform's Identity Server.
+  ACTIVATION
+  ==========
+  The configuration patch inside this file is guarded by the Sitecore env:require
+  mechanism.  It only takes effect when the following environment variable is set
+  to any non-empty value on the CM instance:
+
+      SITECORE_SPE_OAUTH=true
+
+  When the variable is absent the file is loaded by Sitecore but the entire
+  <sitecore> block is silently skipped, leaving the default
+  SharedSecretAuthenticationProvider in place.  No manual rename or file
+  deployment change is needed — just set the environment variable in XM Cloud
+  (or in docker-compose / Azure App Service settings) to enable OAuth support.
 
   SECURITY NOTES
   ==============
@@ -34,8 +43,9 @@
   Stop-ScriptSession -Session $session
 -->
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/"
-               xmlns:role="http://www.sitecore.net/xmlconfig/role/">
-  <sitecore role:require="Standalone or ContentManagement or XMCloud">
+               xmlns:role="http://www.sitecore.net/xmlconfig/role/"
+               xmlns:env="http://www.sitecore.net/xmlconfig/env/">
+  <sitecore role:require="Standalone or ContentManagement or XMCloud" env:require="SITECORE_SPE_OAUTH">
     <powershell>
       <authenticationProvider type="Spe.Core.Settings.Authorization.OAuthBearerTokenAuthenticationProvider, Spe">
 

--- a/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
+++ b/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
@@ -54,21 +54,28 @@
           At least one entry in the token's "aud" claim must match an entry here
           (case-insensitive).  Leave the list empty to accept any audience (not recommended).
 
+          NOTE: The audience ("aud" claim) identifies the *resource server* the token was
+          issued for — it is NOT the same as a scope.  Typical forms are a URI such as
+          "https://your-cm-host.sitecorecloud.io" or a client/application ID assigned by
+          your IdP.  Inspect an actual access token (e.g. paste it into jwt.io) to find
+          the exact value issued by your authorization server.
+
+          *** XM CLOUD ***
+          Decode a real XM Cloud access token and use the value(s) found in its "aud" claim.
+
           *** NON-XM CLOUD OPERATORS ***
-          The default value "xmcloud.cm:admin" is specific to Sitecore XM Cloud.
-          If you are running on a different topology (on-premises Sitecore Identity Server,
-          Azure AD, Okta, or any other IdP), replace this value with the audience your
-          Identity Server issues — commonly the ClientId or a resource URI configured
-          in that IdP.  Using the wrong value will silently reject every token.
+          Replace the example below with the audience your Identity Server issues —
+          commonly a resource URI or ClientId configured in Sitecore Identity Server,
+          Azure AD, Okta, or your IdP of choice.  Using the wrong value will silently
+          reject every token.
 
           IMPORTANT: Removing all <audience> entries disables audience validation entirely.
           Any bearer token with a valid expiry will then be accepted regardless of its
           intended audience.  Always configure at least one entry in production.
         -->
         <allowedAudiences hint="list">
-          <!-- For XM Cloud the audience is typically the scope used for CM API access.
-               Adjust to match the audience configured in your Identity Server. -->
-          <audience>xmcloud.cm:admin</audience>
+          <!-- Replace with the "aud" claim value from your actual access token.
+               Example: <audience>https://your-cm-host.sitecorecloud.io</audience> -->
         </allowedAudiences>
 
         <!--

--- a/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
+++ b/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config
@@ -53,6 +53,17 @@
           allowedAudiences
           At least one entry in the token's "aud" claim must match an entry here
           (case-insensitive).  Leave the list empty to accept any audience (not recommended).
+
+          *** NON-XM CLOUD OPERATORS ***
+          The default value "xmcloud.cm:admin" is specific to Sitecore XM Cloud.
+          If you are running on a different topology (on-premises Sitecore Identity Server,
+          Azure AD, Okta, or any other IdP), replace this value with the audience your
+          Identity Server issues — commonly the ClientId or a resource URI configured
+          in that IdP.  Using the wrong value will silently reject every token.
+
+          IMPORTANT: Removing all <audience> entries disables audience validation entirely.
+          Any bearer token with a valid expiry will then be accepted regardless of its
+          intended audience.  Always configure at least one entry in production.
         -->
         <allowedAudiences hint="list">
           <!-- For XM Cloud the audience is typically the scope used for CM API access.
@@ -64,6 +75,14 @@
           requiredScopes
           All listed scopes must be present in the token's "scope" claim.
           Leave the list empty to skip scope validation (not recommended).
+
+          *** NON-XM CLOUD OPERATORS ***
+          The default value "xmcloud.cm:admin" is an XM Cloud-specific scope.
+          Replace it with the scope(s) your IdP issues — e.g. "openid sitecore.profile"
+          for Sitecore Identity Server, or a custom application scope for Azure AD / Okta.
+
+          IMPORTANT: Removing all <scope> entries disables scope validation entirely.
+          Always configure at least one meaningful scope in production.
         -->
         <requiredScopes hint="list">
           <scope>xmcloud.cm:admin</scope>

--- a/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config.disabled
+++ b/src/Spe/App_Config/Include/Spe/Spe.OAuthBearer.config.disabled
@@ -1,0 +1,89 @@
+<!--
+  Sitecore PowerShell Extensions
+  OAuthBearerTokenAuthenticationProvider configuration
+
+  PURPOSE
+  =======
+  This file replaces the default SharedSecretAuthenticationProvider with
+  OAuthBearerTokenAuthenticationProvider, enabling SPE remoting to accept
+  external OAuth / OIDC bearer tokens (e.g. an XM Cloud access token with
+  scope "xmcloud.cm:admin") instead of requiring a Username/Password or a
+  SharedSecret.
+
+  WHEN TO ENABLE
+  ==============
+  Enable this file (rename to Spe.OAuthBearer.config) on XM Cloud CM instances
+  or any Sitecore Cloud topology where callers already hold a valid OAuth access
+  token issued by the platform's Identity Server.
+
+  SECURITY NOTES
+  ==============
+  * JWT signature verification is intentionally skipped here because in XM Cloud
+    the token has already been validated by the edge/API-gateway layer before
+    reaching the CM instance.  If you run SPE outside such a trusted proxy you
+    must validate signatures at the network boundary (e.g. API Management).
+  * Always configure allowedAudiences and requiredScopes to restrict which tokens
+    are accepted.
+  * Use requireSecureConnection="true" on the remoting service when possible.
+
+  USAGE EXAMPLE (PowerShell client)
+  ==================================
+  $token = "<your-xmcloud-oauth-access-token>"
+  $session = New-ScriptSession -AccessToken $token -ConnectionUri "https://<cm-host>"
+  Invoke-RemoteScript -Session $session -ScriptBlock { Get-Item "master:\content\home" }
+  Stop-ScriptSession -Session $session
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/"
+               xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+  <sitecore role:require="Standalone or ContentManagement or XMCloud">
+    <powershell>
+      <authenticationProvider type="Spe.Core.Settings.Authorization.OAuthBearerTokenAuthenticationProvider, Spe">
+
+        <!--
+          allowedAudiences
+          At least one entry in the token's "aud" claim must match an entry here
+          (case-insensitive).  Leave the list empty to accept any audience (not recommended).
+        -->
+        <allowedAudiences hint="list">
+          <!-- For XM Cloud the audience is typically the scope used for CM API access.
+               Adjust to match the audience configured in your Identity Server. -->
+          <audience>xmcloud.cm:admin</audience>
+        </allowedAudiences>
+
+        <!--
+          requiredScopes
+          All listed scopes must be present in the token's "scope" claim.
+          Leave the list empty to skip scope validation (not recommended).
+        -->
+        <requiredScopes hint="list">
+          <scope>xmcloud.cm:admin</scope>
+        </requiredScopes>
+
+        <!--
+          usernameClaim
+          Name of the JWT claim whose value becomes the Sitecore username when
+          serviceAccountUsername is not set.  Common values: sub, email, preferred_username.
+          Ignored when serviceAccountUsername is configured.
+        -->
+        <usernameClaim>sub</usernameClaim>
+
+        <!--
+          serviceAccountUsername
+          When set, every successfully validated token causes SPE to switch to this
+          fixed Sitecore account, ignoring the token's identity claims.
+          Ideal for automation pipelines where a single service account runs all remote scripts.
+          Uncomment and set to the Sitecore account that should own remoting executions.
+        -->
+        <!--<serviceAccountUsername>sitecore\admin</serviceAccountUsername>-->
+
+        <!--
+          detailedAuthenticationErrors
+          Set to true to emit detailed rejection reasons to the Sitecore log.
+          Keep false in production to avoid leaking token information.
+        -->
+        <detailedAuthenticationErrors>false</detailedAuthenticationErrors>
+
+      </authenticationProvider>
+    </powershell>
+  </sitecore>
+</configuration>

--- a/src/Spe/App_Config/Include/Spe/Spe.XMCloud.Remoting.config
+++ b/src/Spe/App_Config/Include/Spe/Spe.XMCloud.Remoting.config
@@ -1,0 +1,112 @@
+<!--
+  Sitecore PowerShell Extensions
+  XM Cloud — environment-variable-gated remoting configuration
+
+  PURPOSE
+  =======
+  All SPE remote-facing service endpoints ship with enabled="false" in the base
+  Spe.config to keep the attack surface minimal.  This file lets XM Cloud operators
+  turn on only the remoting features they actually need, purely by setting
+  environment variables — no file edits or config deployments required.
+
+  The file is silently ignored on any role other than XMCloud (role:require guard).
+  On XMCloud, each of the three blocks below is independently activated by its own
+  environment variable.  Variables that are absent or empty leave the corresponding
+  endpoints disabled.
+
+  AVAILABLE ENVIRONMENT VARIABLES
+  ================================
+
+  SITECORE_SPE_REMOTING_ENABLED
+    Enables the "remoting" endpoint used by Invoke-RemoteScript.
+    This is the highest-privilege surface: it allows arbitrary PowerShell execution
+    on the CM via a trusted client session.  Enable only when your CI/CD pipeline
+    or tooling requires remote script execution.
+
+  SITECORE_SPE_REMOTING_FILE_ENABLED
+    Enables the "fileDownload" and "fileUpload" endpoints used by the file-path
+    variants of Send-RemoteItem and Receive-RemoteItem.
+    Enable when you need to push or pull files from the CM file system remotely.
+
+  SITECORE_SPE_REMOTING_MEDIA_ENABLED
+    Enables the "mediaDownload" and "mediaUpload" endpoints used by the media-item
+    variants of Send-RemoteItem and Receive-RemoteItem.
+    Enable when you need to import or export media library items remotely.
+
+  TYPICAL XM CLOUD CI/CD SETUP
+  =============================
+  For a pipeline that only runs remote scripts and uploads media:
+
+      SITECORE_SPE_REMOTING_ENABLED=true
+      SITECORE_SPE_REMOTING_MEDIA_ENABLED=true
+      SITECORE_SPE_OAUTH=true          (from Spe.OAuthBearer.config)
+
+  RELATIONSHIP TO Spe.OAuthBearer.config
+  =======================================
+  These two configuration files are complementary but fully independent:
+    * SITECORE_SPE_OAUTH controls *how* clients authenticate (OAuth bearer vs.
+      SharedSecret).
+    * SITECORE_SPE_REMOTING_* variables control *which* endpoints are open.
+  Any combination is valid, and neither variable implies the other.
+
+  SECURITY NOTES
+  ==============
+  * Only enable the endpoints that your workload requires.
+  * Pair remoting access with a strong authentication strategy (see
+    Spe.OAuthBearer.config for OAuth / XM Cloud token support).
+  * Consider setting requireSecureConnection="true" on each endpoint when TLS
+    is terminated at IIS rather than at the load balancer.
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/"
+               xmlns:role="http://www.sitecore.net/xmlconfig/role/"
+               xmlns:env="http://www.sitecore.net/xmlconfig/env/">
+
+  <!--
+    BLOCK 1 — Script execution (Invoke-RemoteScript)
+    Activated by: SITECORE_SPE_REMOTING_ENABLED=<any non-empty value>
+  -->
+  <sitecore role:require="XMCloud" env:require="SITECORE_SPE_REMOTING_ENABLED">
+    <powershell>
+      <services>
+        <remoting>
+          <patch:attribute name="enabled">true</patch:attribute>
+        </remoting>
+      </services>
+    </powershell>
+  </sitecore>
+
+  <!--
+    BLOCK 2 — File transfer (Send-RemoteItem / Receive-RemoteItem for file paths)
+    Activated by: SITECORE_SPE_REMOTING_FILE_ENABLED=<any non-empty value>
+  -->
+  <sitecore role:require="XMCloud" env:require="SITECORE_SPE_REMOTING_FILE_ENABLED">
+    <powershell>
+      <services>
+        <fileDownload>
+          <patch:attribute name="enabled">true</patch:attribute>
+        </fileDownload>
+        <fileUpload>
+          <patch:attribute name="enabled">true</patch:attribute>
+        </fileUpload>
+      </services>
+    </powershell>
+  </sitecore>
+
+  <!--
+    BLOCK 3 — Media transfer (Send-RemoteItem / Receive-RemoteItem for media items)
+    Activated by: SITECORE_SPE_REMOTING_MEDIA_ENABLED=<any non-empty value>
+  -->
+  <sitecore role:require="XMCloud" env:require="SITECORE_SPE_REMOTING_MEDIA_ENABLED">
+    <powershell>
+      <services>
+        <mediaDownload>
+          <patch:attribute name="enabled">true</patch:attribute>
+        </mediaDownload>
+        <mediaUpload>
+          <patch:attribute name="enabled">true</patch:attribute>
+        </mediaUpload>
+      </services>
+    </powershell>
+  </sitecore>
+
+</configuration>

--- a/src/Spe/Core/Settings/Authorization/OAuthBearerTokenAuthenticationProvider.cs
+++ b/src/Spe/Core/Settings/Authorization/OAuthBearerTokenAuthenticationProvider.cs
@@ -163,7 +163,10 @@ namespace Spe.Core.Settings.Authorization
             }
             else if (audObj is System.Collections.ArrayList arr)
             {
-                foreach (var item in arr) tokenAudiences.Add(item?.ToString());
+                foreach (var item in arr)
+                {
+                    if (item != null) tokenAudiences.Add(item.ToString());
+                }
             }
 
             foreach (var allowed in AllowedAudiences)
@@ -196,7 +199,10 @@ namespace Spe.Core.Settings.Authorization
             }
             else if (scopeObj is System.Collections.ArrayList arr)
             {
-                foreach (var item in arr) tokenScopes.Add(item?.ToString());
+                foreach (var item in arr)
+                {
+                    if (item != null) tokenScopes.Add(item.ToString());
+                }
             }
 
             foreach (var required in RequiredScopes)
@@ -240,7 +246,7 @@ namespace Spe.Core.Settings.Authorization
         private static byte[] Base64UrlDecode(string input)
         {
             if (string.IsNullOrWhiteSpace(input))
-                throw new ArgumentException(nameof(input));
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(input));
 
             var output = input
                 .Replace('-', '+')

--- a/src/Spe/Core/Settings/Authorization/OAuthBearerTokenAuthenticationProvider.cs
+++ b/src/Spe/Core/Settings/Authorization/OAuthBearerTokenAuthenticationProvider.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Web.Script.Serialization;
+using Spe.Abstractions.VersionDecoupling.Interfaces;
+using Spe.Core.Diagnostics;
+
+namespace Spe.Core.Settings.Authorization
+{
+    /// <summary>
+    ///     Authentication provider that accepts external OAuth/OIDC bearer tokens (e.g. XM Cloud access tokens).
+    ///     It validates the token's expiration, audience, and any required claims, then resolves the Sitecore
+    ///     username from a configurable claim or a fixed service-account username.
+    ///
+    ///     JWT signature verification is intentionally skipped because in XM Cloud and other Sitecore Cloud
+    ///     topologies the token has already been validated by the platform's edge/API-gateway layer before it
+    ///     reaches the CM instance.  Operators that run SPE outside such a trusted proxy can front the endpoint
+    ///     with their own gateway that validates the signature.
+    /// </summary>
+    public class OAuthBearerTokenAuthenticationProvider : ISpeAuthenticationProvider
+    {
+        // ── Configuration properties (populated from Sitecore config XML) ──────────────────────────────
+
+        /// <summary>
+        ///     Audiences that are allowed.  At least one of the values in the token's <c>aud</c> claim must
+        ///     match an entry in this list (case-insensitive).  Configured via
+        ///     <c>&lt;allowedAudiences hint="list"&gt;&lt;audience&gt;…&lt;/audience&gt;&lt;/allowedAudiences&gt;</c>.
+        /// </summary>
+        public List<string> AllowedAudiences { get; set; } = new List<string>();
+
+        /// <summary>
+        ///     Scope values that must ALL be present in the token's <c>scope</c> claim (space-delimited string
+        ///     or array).  Configured via
+        ///     <c>&lt;requiredScopes hint="list"&gt;&lt;scope&gt;…&lt;/scope&gt;&lt;/requiredScopes&gt;</c>.
+        /// </summary>
+        public List<string> RequiredScopes { get; set; } = new List<string>();
+
+        /// <summary>
+        ///     Name of the JWT claim whose value is used as the Sitecore username when
+        ///     <see cref="ServiceAccountUsername"/> is not configured.  Defaults to <c>sub</c>.
+        /// </summary>
+        public string UsernameClaim { get; set; } = "sub";
+
+        /// <summary>
+        ///     When set, every successfully validated token causes this fixed Sitecore account to be used
+        ///     regardless of the token's claims.  Useful for automation scenarios where all callers should
+        ///     run as a shared service account (e.g. <c>sitecore\admin</c>).
+        /// </summary>
+        public string ServiceAccountUsername { get; set; }
+
+        /// <summary>
+        ///     When <c>true</c>, authentication errors include additional detail in log messages.
+        /// </summary>
+        public bool DetailedAuthenticationErrors { get; set; }
+
+        // ── ISpeAuthenticationProvider ───────────────────────────────────────────────────────────────
+
+        public bool Validate(string token, string authority, out string username)
+        {
+            username = null;
+
+            if (string.IsNullOrEmpty(token))
+            {
+                return false;
+            }
+
+            var parts = token.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 3)
+            {
+                LogDetail("OAuth bearer token is not a valid three-part JWT.");
+                return false;
+            }
+
+            // ── Decode header (not strictly needed here but validates structure) ──────────────────
+            string payloadJson;
+            try
+            {
+                payloadJson = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+            }
+            catch (Exception ex)
+            {
+                LogDetail($"OAuth bearer token payload could not be decoded: {ex.Message}");
+                return false;
+            }
+
+            var serializer = new JavaScriptSerializer();
+            Dictionary<string, object> payload;
+            try
+            {
+                payload = serializer.Deserialize<Dictionary<string, object>>(payloadJson);
+            }
+            catch (Exception ex)
+            {
+                LogDetail($"OAuth bearer token payload could not be parsed: {ex.Message}");
+                return false;
+            }
+
+            if (!ValidateExpiration(payload)) return false;
+            if (!ValidateAudience(payload)) return false;
+            if (!ValidateScopes(payload)) return false;
+
+            username = ResolveUsername(payload);
+            if (string.IsNullOrEmpty(username))
+            {
+                LogDetail($"OAuth bearer token does not contain the required username claim '{UsernameClaim}'.");
+                return false;
+            }
+
+            PowerShellLog.Debug($"OAuthBearerTokenAuthenticationProvider: token accepted, resolved username '{username}'.");
+            return true;
+        }
+
+        // ── Validation helpers ───────────────────────────────────────────────────────────────────────
+
+        private bool ValidateExpiration(Dictionary<string, object> payload)
+        {
+            if (!payload.TryGetValue("exp", out var expObj))
+            {
+                LogDetail("OAuth bearer token is missing the 'exp' claim.");
+                return false;
+            }
+
+            long exp;
+            try
+            {
+                exp = Convert.ToInt64(expObj);
+            }
+            catch
+            {
+                LogDetail("OAuth bearer token 'exp' claim could not be converted to a long.");
+                return false;
+            }
+
+            var expireUtc = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(exp);
+            if (DateTime.UtcNow >= expireUtc)
+            {
+                LogDetail("OAuth bearer token has expired.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool ValidateAudience(Dictionary<string, object> payload)
+        {
+            if (AllowedAudiences == null || AllowedAudiences.Count == 0)
+            {
+                // No audience restriction configured – allow any audience.
+                return true;
+            }
+
+            if (!payload.TryGetValue("aud", out var audObj))
+            {
+                LogDetail("OAuth bearer token is missing the 'aud' claim but audiences are required.");
+                return false;
+            }
+
+            // aud can be a single string or a JSON array.
+            var tokenAudiences = new List<string>();
+            if (audObj is string s)
+            {
+                tokenAudiences.Add(s);
+            }
+            else if (audObj is System.Collections.ArrayList arr)
+            {
+                foreach (var item in arr) tokenAudiences.Add(item?.ToString());
+            }
+
+            foreach (var allowed in AllowedAudiences)
+            {
+                foreach (var tokenAud in tokenAudiences)
+                {
+                    if (string.Equals(allowed, tokenAud, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+            }
+
+            LogDetail($"OAuth bearer token audience does not match any allowed audience.");
+            return false;
+        }
+
+        private bool ValidateScopes(Dictionary<string, object> payload)
+        {
+            if (RequiredScopes == null || RequiredScopes.Count == 0)
+            {
+                return true;
+            }
+
+            payload.TryGetValue("scope", out var scopeObj);
+            var tokenScopes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (scopeObj is string scopeStr)
+            {
+                foreach (var s in scopeStr.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                    tokenScopes.Add(s);
+            }
+            else if (scopeObj is System.Collections.ArrayList arr)
+            {
+                foreach (var item in arr) tokenScopes.Add(item?.ToString());
+            }
+
+            foreach (var required in RequiredScopes)
+            {
+                if (!tokenScopes.Contains(required))
+                {
+                    LogDetail($"OAuth bearer token is missing required scope '{required}'.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private string ResolveUsername(Dictionary<string, object> payload)
+        {
+            if (!string.IsNullOrEmpty(ServiceAccountUsername))
+            {
+                return ServiceAccountUsername;
+            }
+
+            var claimName = string.IsNullOrEmpty(UsernameClaim) ? "sub" : UsernameClaim;
+            payload.TryGetValue(claimName, out var claimValue);
+            return claimValue?.ToString();
+        }
+
+        // ── Utility ─────────────────────────────────────────────────────────────────────────────────
+
+        private void LogDetail(string message)
+        {
+            if (DetailedAuthenticationErrors)
+            {
+                PowerShellLog.Warn($"OAuthBearerTokenAuthenticationProvider: {message}");
+            }
+            else
+            {
+                PowerShellLog.Debug($"OAuthBearerTokenAuthenticationProvider: {message}");
+            }
+        }
+
+        private static byte[] Base64UrlDecode(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                throw new ArgumentException(nameof(input));
+
+            var output = input
+                .Replace('-', '+')
+                .Replace('_', '/');
+
+            switch (output.Length % 4)
+            {
+                case 2: output += "=="; break;
+                case 3: output += "="; break;
+            }
+
+            return Convert.FromBase64String(output);
+        }
+    }
+}

--- a/src/Spe/Spe.csproj
+++ b/src/Spe/Spe.csproj
@@ -620,7 +620,7 @@
     <Content Include="App_Config\Include\Spe\Spe.IdentityServer.config">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="App_Config\Include\Spe\Spe.OAuthBearer.config.disabled" />
+    <Content Include="App_Config\Include\Spe\Spe.OAuthBearer.config" />
     <Content Include="App_Config\Include\Spe\Spe.Serialization.config" />
     <Content Include="App_Config\Include\Rainbow.config" />
     <Content Include="App_Config\Include\Unicorn\Unicorn.zSharedSecret.config.example" />

--- a/src/Spe/Spe.csproj
+++ b/src/Spe/Spe.csproj
@@ -592,6 +592,7 @@
     <Compile Include="Templates.cs" />
     <Compile Include="Texts.cs" />
     <Compile Include="Utility\DateConverter.cs" />
+    <Compile Include="Core\Settings\Authorization\OAuthBearerTokenAuthenticationProvider.cs" />
     <Compile Include="Core\Settings\Authorization\SharedSecretAuthenticationProvider.cs" />
     <Compile Include="Utility\UrlHandleWrapper.cs" />
     <Compile Include="Version.cs" />
@@ -619,6 +620,7 @@
     <Content Include="App_Config\Include\Spe\Spe.IdentityServer.config">
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="App_Config\Include\Spe\Spe.OAuthBearer.config.disabled" />
     <Content Include="App_Config\Include\Spe\Spe.Serialization.config" />
     <Content Include="App_Config\Include\Rainbow.config" />
     <Content Include="App_Config\Include\Unicorn\Unicorn.zSharedSecret.config.example" />


### PR DESCRIPTION
This pull request introduces support for OAuth bearer token authentication across the Sitecore PowerShell Extensions (SPE) remoting commands, making it easier and more secure to authenticate using external tokens (such as those from XM Cloud) instead of traditional username/password or shared secret approaches. It also adds new Sitecore configuration files to enable OAuth and control remoting endpoints via environment variables, streamlining deployment and security management in cloud environments.

The most important changes are:

**OAuth Bearer Token Authentication Support:**

* All major SPE remoting cmdlets (`Invoke-RemoteScript`, `Invoke-RemoteScriptAsync`, `Send-RemoteItem`, `Receive-RemoteItem`, and `New-ScriptSession`) now accept an `AccessToken` parameter, allowing clients to authenticate using an external OAuth bearer token. The code ensures the token is included as a `Bearer` header in HTTP requests when provided. (`Modules/SPE/Invoke-RemoteScript.ps1`, `Modules/SPE/New-ScriptSession.ps1`, `Modules/SPE/Send-RemoteItem.ps1`, `Modules/SPE/Receive-RemoteItem.ps1`) [[1]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R195-R198) [[2]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R227-R230) [[3]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R309-R311) [[4]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2L327-R340) [[5]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R437-R439) [[6]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R496-R498) [[7]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R511-R516) [[8]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7R26-R29) [[9]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7L50-R55) [[10]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7R67-R70) [[11]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7R96) [[12]](diffhunk://#diff-73842e044b6f98dd0b92387dfe8463395352c27e3b7109cee99ad8b2b7eb2d6fR88-R93) [[13]](diffhunk://#diff-73842e044b6f98dd0b92387dfe8463395352c27e3b7109cee99ad8b2b7eb2d6fR146-R148) [[14]](diffhunk://#diff-73842e044b6f98dd0b92387dfe8463395352c27e3b7109cee99ad8b2b7eb2d6fL169-R180) [[15]](diffhunk://#diff-108abe1d17844990c5467827418d7cbd622a0c77b2c5853b2e4528115947e03dR81-R84) [[16]](diffhunk://#diff-108abe1d17844990c5467827418d7cbd622a0c77b2c5853b2e4528115947e03dR150-R152) [[17]](diffhunk://#diff-108abe1d17844990c5467827418d7cbd622a0c77b2c5853b2e4528115947e03dL177-R186)

**Sitecore Configuration for OAuth and Remoting Endpoints:**

* Added `Spe.OAuthBearer.config`, a new Sitecore configuration file that enables OAuth bearer token authentication for SPE remoting when the `SITECORE_SPE_OAUTH` environment variable is set. This file provides extensive documentation and security notes for proper configuration in both XM Cloud and custom environments.
* Added `Spe.XMCloud.Remoting.config`, a new configuration file allowing operators to enable specific SPE remoting endpoints (script execution, file transfer, media transfer) via dedicated environment variables. This helps minimize the attack surface by only enabling required services.

**Parameter Set and Session Handling Improvements:**

* Updated parameter sets and session object handling to support the new `AccessToken` parameter, ensuring that authentication flows seamlessly whether the token is passed directly or stored in a session. [[1]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R309-R311) [[2]](diffhunk://#diff-85a44bd28412377fd0cea38f19057d2c46a450bc058b7c414d448ff60739a9d2R496-R498) [[3]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7L50-R55) [[4]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7R67-R70) [[5]](diffhunk://#diff-b6241b22482085df7966be16485279e4545b549f743e6645f9ca1462789db4a7R96) [[6]](diffhunk://#diff-73842e044b6f98dd0b92387dfe8463395352c27e3b7109cee99ad8b2b7eb2d6fR146-R148) [[7]](diffhunk://#diff-108abe1d17844990c5467827418d7cbd622a0c77b2c5853b2e4528115947e03dR150-R152)

These enhancements modernize SPE remoting authentication, improve security, and make it easier to manage in cloud and automated deployment scenarios.